### PR TITLE
Update language-changer.js

### DIFF
--- a/language-changer.js
+++ b/language-changer.js
@@ -3,7 +3,7 @@ function languageReplacer(match, p1, p2, p3, offset, string) {
   }
 
 function changeDocsLanguage(requestDetails) {
-    let modifiedUrl = requestDetails.url.replace(/(^https?:\/\/docs\.microsoft\.com\/)(\w+-?\w+)([\/*\w*\/*\W*]*)/, languageReplacer);
+    let modifiedUrl = requestDetails.url.replace(/(^https?:\/\/docs\.microsoft\.com\/)(\w{2,3}(?:-\w{2})?)([\/*\w*\/*\W*]*)/, languageReplacer);
 
     if(requestDetails.url === modifiedUrl){
       return;


### PR DESCRIPTION
The language code length is not variable, it's two or three characters in the by Microsoft used ISO 639-1. If a second part is added, the "-" is obligatory. Therefore I added a second optional non-capturing group, which includes "-" and two characters.
This fixes #2